### PR TITLE
pr: history save process with domain publishing event

### DIFF
--- a/src/main/java/io/hhpluslectureapplicationsystem/api/business/model/event/LectureApplySuccessEvent.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/business/model/event/LectureApplySuccessEvent.java
@@ -1,0 +1,43 @@
+package io.hhpluslectureapplicationsystem.api.business.model.event;
+
+import java.time.LocalDateTime;
+
+import org.springframework.context.ApplicationEvent;
+
+import io.hhpluslectureapplicationsystem.api.business.model.entity.LectureApplicationHistory;
+import io.hhpluslectureapplicationsystem.common.mapper.ObjectMapperBasedVoMapper;
+import lombok.Getter;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Getter
+public class LectureApplySuccessEvent extends ApplicationEvent {
+	private final String userId;
+	private final String lectureExternalId;
+	private final String lectureApplicationId;
+	private final boolean success;
+	private final LocalDateTime appliedAt;
+	private final LocalDateTime requestAt;
+
+
+	public static LectureApplySuccessEvent of(Object source, String userId, String lectureId, String lectureApplicationId, LocalDateTime appliedAt, LocalDateTime reqeustAt){
+		return new LectureApplySuccessEvent(source, userId, lectureId, lectureApplicationId, appliedAt, reqeustAt);
+	}
+
+
+	public LectureApplySuccessEvent(Object source, String userId, String lectureExternalId, String lectureApplicationId, LocalDateTime appliedAt, LocalDateTime requestAt) {
+		super(source);
+		this.userId = userId;
+		this.lectureExternalId = lectureExternalId;
+		this.lectureApplicationId = lectureApplicationId;
+		this.success = true;
+		this.appliedAt = appliedAt;
+		this.requestAt = requestAt;
+	}
+
+	public LectureApplicationHistory toEntity(){
+		return ObjectMapperBasedVoMapper.convert(this, LectureApplicationHistory.class);
+	}
+}

--- a/src/main/java/io/hhpluslectureapplicationsystem/api/business/model/event/LectureApplyTryEvent.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/business/model/event/LectureApplyTryEvent.java
@@ -1,0 +1,32 @@
+package io.hhpluslectureapplicationsystem.api.business.model.event;
+
+import java.time.LocalDateTime;
+
+import org.springframework.context.ApplicationEvent;
+
+import io.hhpluslectureapplicationsystem.api.business.model.entity.LectureApplicationHistory;
+import io.hhpluslectureapplicationsystem.common.mapper.ObjectMapperBasedVoMapper;
+import lombok.Getter;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Getter
+public class LectureApplyTryEvent extends ApplicationEvent {
+	private final String userId;
+	private final String lectureExternalId;
+	private final LocalDateTime requestAt;
+
+	public LectureApplyTryEvent(Object source, String userId, String lectureExternalId, LocalDateTime requestAt) {
+		super(source);
+		this.userId = userId;
+		this.lectureExternalId = lectureExternalId;
+		this.requestAt = requestAt;
+	}
+
+	public LectureApplicationHistory toEntity(){
+		return ObjectMapperBasedVoMapper.convert(this, LectureApplicationHistory.class);
+	}
+
+}

--- a/src/main/java/io/hhpluslectureapplicationsystem/api/business/operators/aspect/LectureApplicationAspect.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/business/operators/aspect/LectureApplicationAspect.java
@@ -1,0 +1,31 @@
+package io.hhpluslectureapplicationsystem.api.business.operators.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import io.hhpluslectureapplicationsystem.api.business.model.dto.LectureApplyCommand;
+import io.hhpluslectureapplicationsystem.api.business.model.event.LectureApplyTryEvent;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LectureApplicationAspect {
+
+
+	private final ApplicationEventPublisher eventPublisher;
+
+	@Before("@annotation(io.hhpluslectureapplicationsystem.common.annotation.LogLectureApplyTry)")
+	public void logLectureApplyTry(JoinPoint joinPoint) {
+		Object[] args = joinPoint.getArgs();
+		LectureApplyCommand command = (LectureApplyCommand) args[0];
+		eventPublisher.publishEvent(new LectureApplyTryEvent(this, command.userId(), command.lectureExternalId(), command.requestAt()));
+	}
+}

--- a/src/main/java/io/hhpluslectureapplicationsystem/api/business/operators/eventhandler/LectureApplyEventHandler.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/business/operators/eventhandler/LectureApplyEventHandler.java
@@ -1,0 +1,32 @@
+package io.hhpluslectureapplicationsystem.api.business.operators.eventhandler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import io.hhpluslectureapplicationsystem.api.business.model.event.LectureApplySuccessEvent;
+import io.hhpluslectureapplicationsystem.api.business.model.event.LectureApplyTryEvent;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplyHistoryFactory;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Component
+@RequiredArgsConstructor
+public class LectureApplyEventHandler {
+
+	private final LectureApplyHistoryFactory lectureApplyHistoryFactory;
+
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+	public void handleLectureApplyEvent(LectureApplySuccessEvent event) {
+		lectureApplyHistoryFactory.upsertSuccessEvent(event);
+	}
+
+	@EventListener
+	public void handleLectureApplyTryEvent(LectureApplyTryEvent event) {
+		lectureApplyHistoryFactory.saveTryHistory(event);
+	}
+}

--- a/src/main/java/io/hhpluslectureapplicationsystem/api/infrastructure/persistence/SimpleLectureApplicationHistoryResolver.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/infrastructure/persistence/SimpleLectureApplicationHistoryResolver.java
@@ -1,0 +1,42 @@
+package io.hhpluslectureapplicationsystem.api.infrastructure.persistence;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import io.hhpluslectureapplicationsystem.api.business.model.dto.LectureApplicationHistoryInfo;
+import io.hhpluslectureapplicationsystem.api.business.model.entity.Lecture;
+import io.hhpluslectureapplicationsystem.api.business.model.entity.LectureApplication;
+import io.hhpluslectureapplicationsystem.api.business.model.entity.LectureApplicationHistory;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplicationHistoryResolver;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplicationRepository;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplyHistoryRepository;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Component
+@RequiredArgsConstructor
+public class SimpleLectureApplicationHistoryResolver implements LectureApplicationHistoryResolver {
+	private final LectureApplyHistoryRepository lectureApplyHistoryRepository;
+
+	private final LectureRepository lectureRepository;
+	private final LectureApplicationRepository lectureApplicationRepository;
+
+	@Override
+	public List<LectureApplicationHistoryInfo> getApplicationHistoriesByUserId(String userId) {
+		List<LectureApplicationHistory> histories = lectureApplyHistoryRepository.findByUserId(userId);
+
+		return histories.stream()
+			.filter(LectureApplicationHistory::isSuccess)
+			.map(history -> {
+			Lecture lecture = lectureRepository.findByLectureExternalId(history.getLectureExternalId()).orElse(null);
+			LectureApplication lectureApplication = lectureApplicationRepository.findById(history.getLectureApplicationId()).orElse(null);
+			return LectureApplicationHistoryInfo.from(history, lecture, lectureApplication);
+		}).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/io/hhpluslectureapplicationsystem/api/infrastructure/persistence/SimpleLectureApplyHistoryFactory.java
+++ b/src/main/java/io/hhpluslectureapplicationsystem/api/infrastructure/persistence/SimpleLectureApplyHistoryFactory.java
@@ -1,0 +1,59 @@
+package io.hhpluslectureapplicationsystem.api.infrastructure.persistence;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.hhpluslectureapplicationsystem.api.business.model.entity.LectureApplicationHistory;
+import io.hhpluslectureapplicationsystem.api.business.model.event.LectureApplySuccessEvent;
+import io.hhpluslectureapplicationsystem.api.business.model.event.LectureApplyTryEvent;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplyHistoryFactory;
+import io.hhpluslectureapplicationsystem.api.business.persistence.LectureApplyHistoryRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author : Rene Choi
+ * @since : 2024/06/24
+ */
+@Component
+@RequiredArgsConstructor
+public class SimpleLectureApplyHistoryFactory implements LectureApplyHistoryFactory {
+	private final LectureApplyHistoryRepository historyRepository;
+
+
+	/**
+	 * 특강 신청 ----> || 이력 생성 (비동기) || ---> [ 신청이 완료 - 이력 생성 ]
+	 * 1) 성공 이벤트가 먼저 도달하는 경우 -> 이력이 존재하지 않을 것이므로 새로 생성하여 저장
+	 * 2) 시도 이벤트가 먼저 도달하는 경우 -> 이미 저장된 시도 이력이 존재할 것이므로 해당 이벤트를 조회하여 덮어씀
+	 */
+	@Override
+	@Transactional
+	public void upsertSuccessEvent(LectureApplySuccessEvent event){
+		LectureApplicationHistory history = historyRepository
+			.findByUserIdAndLectureExternalIdAndRequestAt(event.getUserId(), event.getLectureExternalId(), event.getRequestAt())
+			.map(existingHistory -> existingHistory.updateSuccess(event.isSuccess()))
+			.map(existingHistory -> existingHistory.updateLectureApplicationInfoWithSuccessEvent(event))
+			.orElseGet(event::toEntity);
+
+		historyRepository.save(history);
+	}
+
+	/**
+	 * 1) 성공 이벤트가 먼저 도달하는 경우 -> 이미 이력이 생성되었을 것이므로 조회하여 존재한다면 별도로 저장할 필요 없이 return
+	 * 2) 시도 이벤트가 먼저 도달하는 경우 -> 언제나 저장
+	 */
+	@Override
+	@Transactional
+	public void saveTryHistory(LectureApplyTryEvent event) {
+
+		Optional<LectureApplicationHistory> optionalHistory = historyRepository
+			.findByUserIdAndLectureExternalIdAndRequestAt(event.getUserId(), event.getLectureExternalId(), event.getRequestAt());
+
+		if (optionalHistory.isPresent()){
+			return;
+		}
+
+		historyRepository.save(event.toEntity());
+	}
+}


### PR DESCRIPTION
안녕하세요! PR을 최대한 압축해보았습니다!! 

이력을 생성하는 로직을 중심으로 PR을 올렸습니다. 해당 부분을 중점적으로 봐주시면 좋을 것 같습니다. 

구현을 하면서 아래와 내용을 고민했습니다. 

메인 브랜치의 `README`에 작성한 부분 중 일부를 아래에 첨부드리니 함께 리뷰해주시면 감사하겠습니다! 

---




## 3. 사용자 요청 이력 저장하기 챌린지

특강 신청 서비스 API Specs의 요구 사항에 다음과 같은 주문이 있었다.

> 어떤 유저가 특강을 신청했는지 히스토리를 저장해야한다.

이에 대해서 모든 이력을 저장해야 하는 것으로 해석했다. 예를 들어 50개의 요청이 왔을 때, 정상 동작을 한다면 20개는 실패하고 30개는 성공할 것이다. 여기서 30개의 성공에 대한 이력 뿐만 아니라 20개도 저장하여 이력 역시 50개 남아야 한다.

어떻게 구현해야 할까? 챌린지라고 느껴졌다!

사용자 요청 이력을 저장하는 방법에 대해 두 가지 접근 방식을 고민해보았다. 

1. 모든 이력 저장하기
2. 성공한 이력 저장하기

결론적으로는 모든 `시도 요청`에 대해서 신청 로직 처리 전 비동기로 이력을 생성하고, `성공한 이력`에 대해서 동기적으로 생성한다. 

플로우를 설명하기에 앞서 먼저 정의한 이력부터 살펴보자. 


### 이력 속성

이력 엔티티를 다음과 같이 구성했다. 

```java

@Entity
public class LectureApplicationHistory {
	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;
	@Version
	private Long version;
	private String userId;
	private String lectureExternalId;
	private String lectureApplicationId;
	private boolean success;
	private LocalDateTime appliedAt;
	private LocalDateTime requestAt;
}
```


### 이력 생성 전체 과정 

![lecture-history-process-1](https://github.com/renechoi/hhplus-lecture-application-system/assets/115696395/1c222e93-20be-479a-a353-a6b80d22437a)


`LectureApplyService`의 `applyForLecture`에 요청이 들어오면 `@LogLectureApplyTry` 애노테이션에 대한 Aspect가 동작하여 요청을 가로챈다. 

```java
@Override
	@Transactional
	@LogLectureApplyTry
	public LectureApplyInfo applyForLecture(LectureApplyCommand command) {
		Lecture lecture = lectureRepository.findByLectureExternalId(command.lectureExternalId()).orElseThrow(LectureNotFoundException::new);

		lectureApplyValidator.validate(command, lecture);

		LectureApplication lectureApplication = command.toEntity()
			.withPk(lectureApplicationPkGenerator.generate(lecture.getTitle()))
			.withSk(randomUUID().toString().substring(0,12))
			.withLecture(lecture)
			.withAppliedAt(now())
			.asApplied()
			.publish();

		return LectureApplyInfo.from(lectureApplicationRepository.save(lectureApplication));
	}
```

즉, Aspect는 모든 요청에 대해 `LectureApplyTryEvent`를 발행한다. 

```java
@Aspect
@Component
@RequiredArgsConstructor
public class LectureApplicationAspect {


	private final ApplicationEventPublisher eventPublisher;

	@Before("@annotation(io.hhpluslectureapplicationsystem.common.annotation.LogLectureApplyTry)")
	public void logLectureApplyTry(JoinPoint joinPoint) {
		Object[] args = joinPoint.getArgs();
		LectureApplyCommand command = (LectureApplyCommand) args[0];
		eventPublisher.publishEvent(new LectureApplyTryEvent(this, command.userId(), command.lectureExternalId(), command.requestAt()));
	}
}
```

여기서 발행은 비동기적으로 실행된다. 

이후 서비스에서 비즈니스 로직에 따라 신청에 대한 처리가 이루어지고, 만약 신청이 가능하여 성공된다면 이번에는 `AbstractAggregateRoot`를 활용해 도메인 이벤트 방식으로 이벤트를 발행한다. 


```java
@Entity
public class LectureApplication extends AbstractAggregateRoot<LectureApplication> {

	//... 
    
	public LectureApplication publish(){
		this.registerEvent(new LectureApplySuccessEvent(
			this,
			this.userId,
			this.getLectureExternalId(),
			this.lectureApplicationId,
			this.appliedAt,
			this.requestAt
		));
		return this;
	}
```

이때의 이벤트는 다음과 같이 `TransactionalEventListener`의 `TransactionPhase.BEFORE_COMMIT` 옵션으로 커밋 전에 한 트랜잭션 내에서 수행된다.

```java
	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
	public void handleLectureApplyEvent(LectureApplySuccessEvent event) {
		lectureApplyHistoryFactory.upsertSuccessEvent(event);
	}
```

이러한 구현에서 고민한 몇가지 결정사항들에 대해서 살펴보자. 


### 왜 시도 이력은 비동기적으로 처리하고 성공 이력은 트랜잭션을 유지하면서 동기적으로 처리했나?  

특강 신청 시도 이력은 단순히 시도한 사실을 기록하기 위한 것으로, 비동기적으로 처리함으로써 메인 비즈니스 로직에 지장을 주지 않고 빠르게 처리할 수 있다. 
반면에, 성공 이력은 신청이 실제로 성공했음을 의미하므로, 신청 처리가 완료된 후 같은 트랜잭션 내에서 동기적으로 처리하여 데이터의 일관성을 보장해야 한다. 
이는 성공한 신청과 그에 대한 성공 이력이 반드시 함께 저장되도록 하기 위함이다.

다음과 같은 경우의 수를 탐색해보자. 

| 시도 이력 저장 | 성공 이력 저장 | 설명 |
|----------------|----------------|------|
| O              | O              | 정상적인 신청 처리 및 이력 저장, 데이터 일관성 보장 |
| O              | X              | 신청은 성공했으나 성공 이력이 저장되지 않음, 데이터 일관성 문제 |
| X              | O              | 시도 이력이 저장되지 않고 성공 이력만 저장됨, 데이터 일관성 문제 |
| X              | X              | 모든 처리 실패, 시스템 결함이나 비정상적인 상태 |


이러한 이유로 시도 이력은 비동기적으로 처리하여 메인 비즈니스 로직의 성능에 영향을 주지 않도록 하고, 성공 이력은 동기적으로 처리하여 데이터의 일관성을 보장한다.




### 비동기 처리로 인한 잠재적 이슈 

비동기 처리의 경우, 순서가 보장되지 않아 시도 이력보다 성공 이력이 먼저 저장될 수 있다.

예를 들어 앞선 다이어그램에서 비동기 처리 부분이 다음 그림과 같이 비순차적으로 실행된다면 어떨까? 


![lecture-history-process-2](https://github.com/renechoi/hhplus-lecture-application-system/assets/115696395/f9f0e54b-1d4a-4836-9b72-1386b00547b7)


이와 같이 성공 이력이 시도 이력보다 먼저 도착하게 된다. 
이로 인해 성공 이벤트가 먼저 처리되고 성공 이력이 저장된 후 시도 이벤트가 나중에 도착할 경우, 성공한 신청임에도 불구하고 시도 이력이 뒤늦게 저장되어 이력 필드인 `success`가 `true`가 아니라 `false`로 기록될 수 있다. 

어떻게 해결할 수 있을까? 


### 저장 로직 세부 구현

이 문제를 해결하기 위해 `SimpleLectureApplyHistoryFactory` 클래스에서는 성공 이벤트와 시도 이벤트를 처리하는 로직을 다음과 같이 구현했다.

성공 이벤트에 대해서는 다음과 같은 두 가지 경우의 수를 고려할 수 있다.
1. 성공 이벤트가 먼저 도달하는 경우: 이력이 존재하지 않을 것이므로 새로 생성하여 저장한다.
2. 시도 이벤트가 먼저 도달하는 경우: 이미 저장된 시도 이력이 존재하므로 해당 이벤트를 조회하여 덮어쓴다.

```java
@Override
@Transactional
public void upsertSuccessEvent(LectureApplySuccessEvent event){
	LectureApplicationHistory history = historyRepository
		.findByUserIdAndLectureExternalIdAndRequestAt(event.getUserId(), event.getLectureExternalId(), event.getRequestAt())
		.map(existingHistory -> existingHistory.updateSuccess(event.isSuccess()))
		.map(existingHistory -> existingHistory.updateLectureApplicationInfoWithSuccessEvent(event))
		.orElseGet(event::toEntity);

	historyRepository.save(history);
}
```

전체 시도 이벤트에 대해서는 다음과 같은 두 가지 경우의 수를 고려할 수 있다.
1. 성공 이벤트가 먼저 도달하는 경우: 이미 이력이 생성되었을 것이므로 조회하여 존재한다면 별도로 저장할 필요 없이 리턴한다.
2. 시도 이벤트가 먼저 도달하는 경우: 언제나 저장한다.

```java
@Override
@Transactional
public void saveTryHistory(LectureApplyTryEvent event) {
	Optional<LectureApplicationHistory> optionalHistory = historyRepository
		.findByUserIdAndLectureExternalIdAndRequestAt(event.getUserId(), event.getLectureExternalId(), event.getRequestAt());

	if (optionalHistory.isPresent()){
		return;
	}

	historyRepository.save(event.toEntity());
}
```



##### 즉,

1. **성공 이벤트가 먼저 도달한 경우**:
    - 성공 이벤트가 도착하면, `LectureApplySuccessEvent`를 통해 성공 이력을 업데이트하거나 새로 생성한다.
    - 시도 이력이 나중에 도착하면, 기존 이력을 확인하고 덮어쓴다.

2. **시도 이벤트가 먼저 도달한 경우**:
    - 시도 이벤트가 도착하면, `LectureApplyTryEvent`를 통해 시도 이력을 저장한다.
    - 성공 이벤트가 나중에 도착하면, 기존 시도 이력을 성공 이력으로 업데이트한다.



### 검증 

기본 시나리오에 대해서 다음과 같이 테스트했다.


![apply-default-cucumber-scenario](https://github.com/renechoi/hhplus-lecture-application-system/assets/115696395/11dfa715-9113-4d01-84f9-8d32102491d5)


Database에 정상적으로 하나의 이력으로 생성되는 것을 볼 수 있다. 

![apply-default-cucumber-scenario-result](https://github.com/renechoi/hhplus-lecture-application-system/assets/115696395/9c055ad3-d0d8-4109-a4a0-600e90504bca)





